### PR TITLE
Add cli to load archive

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Build and publish gem
         uses: dawidd6/action-publish-gem@v1
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          api_key: ${{secrets.RUBYGEMS_API_KEY}}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bundle` to install dependencies. Then, run `rake spec` to run the tests and `rake rubocop` to check for rubocop offences. 
 
 To install this gem onto your local machine, run the following. **Note** - You must add any new files to git first.
 

--- a/bin/load_archive
+++ b/bin/load_archive
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require 'puma-redeploy'
+require 'logger'
+
+def deploy_archive(app_dir, watch_file, logger)
+  handler = Puma::Redeploy::DeployerFactory.create(target: app_dir, watch_file: watch_file,
+                                                   logger: logger)
+  handler.deploy(source: handler.archive_file)
+end
+
+logger = Logger.new($stdout)
+
+if ARGV.size != 2
+  logger.error 'You must specify the application directory and watch file'
+  logger.info 'load_archive <app directory> <watch file>'
+  logger.info 'e.g. load_archive /app /build/pkg/watch.me'
+end
+
+app_dir = ARGV[0]
+watch_file = ARGV[1]
+
+if File.exist?(watch_file) && Dir.exist?(app_dir)
+  deploy_archive(app_dir, watch_file, logger)
+else
+  logger.error "watch_file #{watch_file} does not exist" unless File.exist?(watch_file)
+  logger.error "app_dir #{app_dir} does not exist" unless Dir.exist?(app_dir)
+end

--- a/lib/puma/plugin/redeploy.rb
+++ b/lib/puma/plugin/redeploy.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 require 'puma-redeploy'
 # require 'puma/plugin'
 # require 'puma/redeploy/dsl'

--- a/lib/puma/redeploy/version.rb
+++ b/lib/puma/redeploy/version.rb
@@ -2,6 +2,6 @@
 
 module Puma
   module Redeploy
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/puma-redeploy.gemspec
+++ b/puma-redeploy.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
+  spec.executables = ['load_archive']
+
   spec.metadata['allowed_push_host'] = "Set to 'http://mygemserver.com'"
 
   spec.metadata['homepage_uri'] = spec.homepage
@@ -27,8 +29,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = 'bin'
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'rake', '~> 13.0.6'


### PR DESCRIPTION
### Description
> Add cli to load archive. This is to be used during the application startup process before Puma loads.
For example:
```
load_archive /app /build/pkg/watch.me
```

This will allow us to remove this code and let the gem do the loading and unzipping. https://github.com/tbeauvais/puma-redeploy-test-app/blob/master/run.sh#L3-L7

### Your checklist for this pull request
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
