### PR TITLE
Add support to run commands prior to redeploy using a yaml watch file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.4
+
+**Features:**
+
+- Add support to run commands prior to redeploy using a yaml watch file. This is useful for running a migration or bundle gems.
+
 ## v0.3.3
 
 **Fixes and enhancements:**

--- a/README.md
+++ b/README.md
@@ -51,17 +51,23 @@ redeploy_watch_delay 15
 
 ```
 
-The watch file must contain the path to the current archive. This can be a file path or S3 URL.
-
+The watch file can contain an optional list of commands to run and the required archive_location. The archive_location can be a file path or S3 URL
 For example when using a file:
-```
-/app/pkg/test_app_0.0.3.zip
+```yaml
+---
+commands:
+  - bundle 
+archive_location: /app/pkg/test_app_0.0.3.zip
 ```
 
 For example when using S3:
+```yaml
+---
+commands:
+  - bundle 
+archive_location: s3://puma-test-app-archives/test_app_0.0.3.zip
 ```
-s3://puma-test-app-archives/test_app_0.0.3.zip
-```
+
 
 ### Archive Loader
 The `archive-loader` is a cli used to fetch and deploy the application archive prior to starting the puma server. This is useful when the application code does not exist in the runtime container.
@@ -76,8 +82,9 @@ Usage: archive-loader [options]. Used to load the archive prior to starting the 
 
 For example this will fetch and unzip the application archive and then start puma.
 ```shell
-archive-loader -a /app -w /app/pkg/watch.me && bundle exec puma -C config/puma.rb
+archive-loader -a /app -w /app/pkg/watch.yml && bundle exec puma -C config/puma.rb
 ```
+
 
 ## Development
 

--- a/bin/archive-loader
+++ b/bin/archive-loader
@@ -9,7 +9,12 @@ require 'optparse'
 def deploy_archive(app_dir, watch_file, logger)
   handler = Puma::Redeploy::DeployerFactory.create(target: app_dir, watch_file:,
                                                    logger:)
-  handler.deploy(source: handler.archive_file)
+
+  watch_file_data = handler.watch_file_data
+
+  archive_file = handler.archive_file(watch_file_data[:archive_location])
+
+  handler.deploy(source: archive_file)
 end
 
 def option_parser(opts)

--- a/lib/puma/plugin/redeploy.rb
+++ b/lib/puma/plugin/redeploy.rb
@@ -27,9 +27,15 @@ def monitor_loop(handler, delay, launcher, logger)
 
     next unless handler.needs_redeploy?
 
-    logger.info "Puma phased_restart begin file=#{handler.watch_file} archive=#{handler.archive_file}"
+    watch_file_data = handler.watch_file_data
 
-    handler.deploy(source: handler.archive_file)
+    archive_file = handler.archive_file(watch_file_data[:archive_location])
+
+    logger.info "Puma phased_restart begin file=#{handler.watch_file} archive=#{archive_file}"
+
+    Puma::Redeploy::CommandRunner.new(commands: watch_file_data[:commands], logger:).run
+
+    handler.deploy(source: archive_file)
 
     launcher.phased_restart
   end

--- a/lib/puma/redeploy/base_handler.rb
+++ b/lib/puma/redeploy/base_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'yaml'
 
 module Puma
   module Redeploy
@@ -23,6 +24,15 @@ module Puma
       end
 
       def_delegators :@deployer, :deploy
+
+      def watch_file_data
+        watch_file_content = read_watch_object
+        results = YAML.safe_load(watch_file_content, symbolize_names: true)
+        return results if results.is_a?(Hash)
+
+        # old style where the file contains only the archive location
+        { commands: [], archive_location: results }
+      end
 
       private
 

--- a/lib/puma/redeploy/command_runner.rb
+++ b/lib/puma/redeploy/command_runner.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Puma
+  module Redeploy
+    # Runs commands before redeploy process
+    class CommandRunner
+      attr_reader :commands, :runner
+
+      def initialize(commands:, logger:, runner: Open3)
+        @logger = logger
+        @commands = commands || []
+        @runner = runner
+      end
+
+      def run
+        commands.each do |command|
+          @logger.info "running command: #{command}"
+          stdout, stderr, status = runner.capture3(command)
+          @logger.info "command stdout: #{stdout}"
+          @logger.info "command status: #{status.exitstatus}"
+          @logger.error "command stderr: #{stderr}" if status.exitstatus != 0
+        end
+      end
+    end
+  end
+end

--- a/lib/puma/redeploy/file_handler.rb
+++ b/lib/puma/redeploy/file_handler.rb
@@ -11,11 +11,17 @@ module Puma
         @touched_at = touched_at
       end
 
-      def archive_file
-        File.read(watch_file).strip
+      def archive_file(archive_location)
+        archive_location
       end
 
       private
+
+      def read_watch_object
+        File.read(watch_file).strip
+      rescue StandardError => e
+        logger.warn "Error reading watch file #{watch_file}. Error:#{e.message}"
+      end
 
       def touched_at
         if File.exist?(watch_file)

--- a/lib/puma/redeploy/s3_handler.rb
+++ b/lib/puma/redeploy/s3_handler.rb
@@ -16,11 +16,10 @@ module Puma
         @touched_at = touched_at
       end
 
-      def archive_file
-        s3_url = read_watch_object
-        return unless s3_url
+      def archive_file(archive_location)
+        return unless archive_location
 
-        archive_bucket_name, archive_object_key = s3_object_reference(s3_url)
+        archive_bucket_name, archive_object_key = s3_object_reference(archive_location)
 
         response = s3_client.get_object(bucket: archive_bucket_name, key: archive_object_key)
 
@@ -29,7 +28,7 @@ module Puma
         File.binwrite(file_name, response.body.read)
         file_name
       rescue StandardError => e
-        logger.warn "Error reading fetching archive file for #{s3_url}. Error:#{e.message}"
+        logger.warn "Error reading fetching archive file for #{archive_location}. Error:#{e.message}"
       end
 
       private
@@ -49,7 +48,7 @@ module Puma
 
         object.body.read.strip
       rescue StandardError => e
-        logger.warn "Error reading url from  watch file #{bucket_name}/#{object_key}. Error:#{e.message}"
+        logger.warn "Error reading watch file #{bucket_name}/#{object_key}. Error:#{e.message}"
       end
 
       def touched_at

--- a/lib/puma/redeploy/version.rb
+++ b/lib/puma/redeploy/version.rb
@@ -2,6 +2,6 @@
 
 module Puma
   module Redeploy
-    VERSION = '0.3.3'
+    VERSION = '0.3.4'
   end
 end

--- a/spec/puma/redeploy/base_handler_spec.rb
+++ b/spec/puma/redeploy/base_handler_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'yaml'
+
+RSpec.describe Puma::Redeploy::BaseHandler do
+  subject(:handler) { Puma::Redeploy::FileHandler.new(watch_file:, deployer:, logger:) }
+
+  let(:deployer) { instance_double(Puma::Redeploy::ZipDeployer, deploy: nil) }
+  let(:logger) { instance_double(Logger, info: nil) }
+
+  describe '#watch_file_data' do
+    let(:archive_name) { 'archive.1.0.0.zip' }
+    let(:watch_file) do
+      Tempfile.new.tap do |file|
+        file.write(watch_file_content)
+        file.close
+      end.path
+    end
+
+    context 'when file contains yaml' do
+      let(:watch_file_content) { { 'commands' => ['ls'], 'archive_location' => archive_name }.to_yaml }
+
+      it 'returns proper hash' do
+        expect(handler.watch_file_data).to eq({ commands: ['ls'], archive_location: archive_name })
+      end
+    end
+
+    context 'when file contains archive name' do
+      let(:watch_file_content) { archive_name }
+
+      it 'returns proper hash' do
+        expect(handler.watch_file_data).to eq({ commands: [], archive_location: archive_name })
+      end
+    end
+  end
+end

--- a/spec/puma/redeploy/command_runner_spec.rb
+++ b/spec/puma/redeploy/command_runner_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+RSpec.describe Puma::Redeploy::CommandRunner do
+  subject(:command_runner) { described_class.new(commands:, logger:, runner:) }
+
+  let(:commands) { ['ls'] }
+  let(:status_code) { 0 }
+  let(:status) { instance_double(Process::Status, exitstatus: status_code) }
+  let(:logger) { instance_double(Logger, info: nil, error: nil) }
+  let(:results) { ['success', '', status] }
+  let(:runner) { class_double(Open3, capture3: results) }
+
+  describe '#run' do
+    it 'invokes runner to execute command' do
+      command_runner.run
+      expect(runner).to have_received(:capture3).with('ls')
+    end
+
+    it 'logs command' do
+      command_runner.run
+      expect(logger).to have_received(:info).with('running command: ls')
+    end
+
+    it 'logs stdout' do
+      command_runner.run
+      expect(logger).to have_received(:info).with('command stdout: success')
+    end
+
+    it 'does not log stderr' do
+      command_runner.run
+      expect(logger).not_to have_received(:error)
+    end
+
+    it 'logs exit status' do
+      command_runner.run
+      expect(logger).to have_received(:info).with('command status: 0')
+    end
+
+    context 'with error' do
+      let(:results) { ['failed', 'error processing', status] }
+      let(:status_code) { 1 }
+
+      it 'logs stderr' do
+        command_runner.run
+        expect(logger).to have_received(:error).with('command stderr: error processing')
+      end
+    end
+
+    context 'with nil commands' do
+      let(:commands) { nil }
+
+      it 'does not try to run command' do
+        command_runner.run
+        expect(runner).not_to have_received(:capture3)
+      end
+    end
+  end
+end

--- a/spec/puma/redeploy/file_handler_spec.rb
+++ b/spec/puma/redeploy/file_handler_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Puma::Redeploy::FileHandler do
   let(:deployer) { instance_double(Puma::Redeploy::ZipDeployer, deploy: nil) }
   let(:logger) { instance_double(Logger, info: nil) }
 
-  describe '.needs_redeploy?' do
+  describe '#needs_redeploy?' do
     context 'when file does not exist' do
       let(:watch_file) { 'does_not_exist' }
 
@@ -43,7 +43,7 @@ RSpec.describe Puma::Redeploy::FileHandler do
     end
   end
 
-  describe '.archive_file' do
+  describe '#archive_file' do
     let(:archive_name) { 'archive.1.0.0.zip' }
 
     context 'when file exist' do
@@ -55,7 +55,7 @@ RSpec.describe Puma::Redeploy::FileHandler do
       end
 
       it 'returns archive name' do
-        expect(file_handler.archive_file).to eq archive_name
+        expect(file_handler.archive_file(archive_name)).to eq archive_name
       end
     end
   end


### PR DESCRIPTION
### Description
> Add support to run commands prior to redeploying using a yaml watch file.

### Your checklist for this pull request
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
