### PR TITLE
Fix the order when running commands to run after unzip archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.0
+
+**Fixes and enhancements:**
+
+- Fix the order when running commands to run after unzip archive. Also bump to 0.4.0
+
+
 ## v0.3.4
 
 **Features:**

--- a/lib/puma/plugin/redeploy.rb
+++ b/lib/puma/plugin/redeploy.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require 'puma-redeploy'
-# require 'puma/plugin'
-# require 'puma/redeploy/dsl'
-# require 'puma/redeploy/file_handler'
-# require 'puma/redeploy/file_deployer'
-# require 'puma/redeploy/deployer_factory'
 require 'logger'
 
 Puma::Plugin.create do
@@ -28,14 +23,13 @@ def monitor_loop(handler, delay, launcher, logger)
     next unless handler.needs_redeploy?
 
     watch_file_data = handler.watch_file_data
-
     archive_file = handler.archive_file(watch_file_data[:archive_location])
 
     logger.info "Puma phased_restart begin file=#{handler.watch_file} archive=#{archive_file}"
 
-    Puma::Redeploy::CommandRunner.new(commands: watch_file_data[:commands], logger:).run
-
     handler.deploy(source: archive_file)
+
+    Puma::Redeploy::CommandRunner.new(commands: watch_file_data[:commands], logger:).run
 
     launcher.phased_restart
   end

--- a/lib/puma/redeploy/version.rb
+++ b/lib/puma/redeploy/version.rb
@@ -2,6 +2,6 @@
 
 module Puma
   module Redeploy
-    VERSION = '0.3.4'
+    VERSION = '0.4.0'
   end
 end


### PR DESCRIPTION
### Description
> Fix the order when running commands to run after unzip archive

### Your checklist for this pull request
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
